### PR TITLE
remove functions to read into byte slice, and use Reader

### DIFF
--- a/code.go
+++ b/code.go
@@ -1,9 +1,12 @@
 package msgpack
 
+// Byte returns the byte representation of the Code
 func (t Code) Byte() byte {
 	return byte(t)
 }
 
+// IsMapFamily returns true if the given code is equivalent to
+// one of the `map` family in msgpack
 func IsMapFamily(c Code) bool {
 	b := c.Byte()
 	return (b >= FixMap0.Byte() && b <= FixMap15.Byte()) ||

--- a/interface.go
+++ b/interface.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 )
 
+// Code represents the first by in a msgpack element. It tell us
+// the data layout that follows it
 type Code byte
 
 const (


### PR DESCRIPTION
With msgpack.Reader we no longer need a temporary buffer.